### PR TITLE
All form elements can now accept params via URL

### DIFF
--- a/console/src/lib/tasks/Checkbox.svelte
+++ b/console/src/lib/tasks/Checkbox.svelte
@@ -18,11 +18,13 @@
 		checked: param.default || false
 	};
 
-	onMount(() => {
-		fieldValue = $page.url.searchParams.get(param.name) === 'true';
-	});
+	let fieldValue = param.default || false;
+	if ($page.url.searchParams.get(param.name) === 'false') {
+		fieldValue = false;
+	} else if ($page.url.searchParams.get(param.name) === 'true') {
+		fieldValue = true;
+	}
 
-	let fieldValue = param.default;
 	$: fieldValue, setValue();
 
 	const setValue = () => {

--- a/console/src/lib/tasks/Checkbox.svelte
+++ b/console/src/lib/tasks/Checkbox.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
 	import { Checkbox } from 'flowbite-svelte';
+	import { onMount } from 'svelte';
 
 	import type { BoolParam } from './api';
 
@@ -15,6 +16,15 @@
 		label,
 		checked: param.default || false
 	};
+
+	onMount(() => {
+		const urlParams = new URLSearchParams(window.location.search);
+		for (const [key, value] of urlParams) {
+			if (key === param.name) {
+				fieldValue = value === 'true';
+			}
+		}
+	});
 
 	let fieldValue = param.default;
 	$: fieldValue, setValue();

--- a/console/src/lib/tasks/Checkbox.svelte
+++ b/console/src/lib/tasks/Checkbox.svelte
@@ -2,6 +2,7 @@
 	import type { Writable } from 'svelte/store';
 	import { Checkbox } from 'flowbite-svelte';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 
 	import type { BoolParam } from './api';
 
@@ -18,12 +19,7 @@
 	};
 
 	onMount(() => {
-		const urlParams = new URLSearchParams(window.location.search);
-		for (const [key, value] of urlParams) {
-			if (key === param.name) {
-				fieldValue = value === 'true';
-			}
-		}
+		fieldValue = $page.url.searchParams.get(param.name) === 'true';
 	});
 
 	let fieldValue = param.default;

--- a/console/src/lib/tasks/Input.svelte
+++ b/console/src/lib/tasks/Input.svelte
@@ -2,6 +2,7 @@
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 
 	import type { StrParam } from './api';
 
@@ -25,12 +26,7 @@
 	}
 
 	onMount(() => {
-		const urlParams = new URLSearchParams(window.location.search);
-		for (const [key, value] of urlParams) {
-			if (key === param.name) {
-				fieldValue = value;
-			}
-		}
+		fieldValue = $page.url.searchParams.get(param.name) || '';
 	});
 
 	let fieldValue = param.default;

--- a/console/src/lib/tasks/Input.svelte
+++ b/console/src/lib/tasks/Input.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
+	import { onMount } from 'svelte';
 
 	import type { StrParam } from './api';
 
@@ -22,6 +23,15 @@
 	if (param.required) {
 		fieldValidators.push(required);
 	}
+
+	onMount(() => {
+		const urlParams = new URLSearchParams(window.location.search);
+		for (const [key, value] of urlParams) {
+			if (key === param.name) {
+				fieldValue = value;
+			}
+		}
+	});
 
 	let fieldValue = param.default;
 	$: fieldValue, setValue();

--- a/console/src/lib/tasks/Input.svelte
+++ b/console/src/lib/tasks/Input.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
-	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 
 	import type { StrParam } from './api';
@@ -25,11 +24,8 @@
 		fieldValidators.push(required);
 	}
 
-	onMount(() => {
-		fieldValue = $page.url.searchParams.get(param.name) || '';
-	});
+	let fieldValue = $page.url.searchParams.get(param.name) || param.default;
 
-	let fieldValue = param.default;
 	$: fieldValue, setValue();
 
 	const setValue = () => {

--- a/console/src/lib/tasks/NumberInput.svelte
+++ b/console/src/lib/tasks/NumberInput.svelte
@@ -2,6 +2,7 @@
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 
 	import type { NumberParam } from './api';
 
@@ -26,12 +27,8 @@
 	}
 
 	onMount(() => {
-		const urlParams = new URLSearchParams(window.location.search);
-		for (const [key, value] of urlParams) {
-			if (key === param.name) {
-				fieldValue = Number(value);
-			}
-		}
+		const valueFromUrl = $page.url.searchParams.get(param.name);
+		fieldValue = valueFromUrl ? Number(valueFromUrl) : undefined;
 	});
 
 	let fieldValue = param.default;

--- a/console/src/lib/tasks/NumberInput.svelte
+++ b/console/src/lib/tasks/NumberInput.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
+	import { onMount } from 'svelte';
 
 	import type { NumberParam } from './api';
 
@@ -23,6 +24,15 @@
 	if (param.required) {
 		fieldValidators.push(required);
 	}
+
+	onMount(() => {
+		const urlParams = new URLSearchParams(window.location.search);
+		for (const [key, value] of urlParams) {
+			if (key === param.name) {
+				fieldValue = Number(value);
+			}
+		}
+	});
 
 	let fieldValue = param.default;
 	$: fieldValue, setValue();

--- a/console/src/lib/tasks/NumberInput.svelte
+++ b/console/src/lib/tasks/NumberInput.svelte
@@ -26,12 +26,9 @@
 		fieldValidators.push(required);
 	}
 
-	onMount(() => {
-		const valueFromUrl = $page.url.searchParams.get(param.name);
-		fieldValue = valueFromUrl ? Number(valueFromUrl) : undefined;
-	});
+	const valueFromUrl = $page.url.searchParams.get(param.name);
+	let fieldValue = valueFromUrl ? Number(valueFromUrl) : undefined || param.default;
 
-	let fieldValue = param.default;
 	$: fieldValue, setValue();
 
 	const setValue = () => {

--- a/console/src/lib/tasks/NumberInput.svelte
+++ b/console/src/lib/tasks/NumberInput.svelte
@@ -26,8 +26,14 @@
 		fieldValidators.push(required);
 	}
 
+	// Get value from the URL if params match param.name
 	const valueFromUrl = $page.url.searchParams.get(param.name);
-	let fieldValue = valueFromUrl ? Number(valueFromUrl) : param.default;
+
+	// Set fieldValue to valueFromUrl
+	// If its a number, set it to that number
+	// If its undefined and there's no param.default, set it to undefined
+	// If its undefined but there is a param.default, set it to param.default
+	let fieldValue = valueFromUrl ? Number(valueFromUrl) : undefined || param.default;
 
 	$: fieldValue, setValue();
 

--- a/console/src/lib/tasks/NumberInput.svelte
+++ b/console/src/lib/tasks/NumberInput.svelte
@@ -27,7 +27,7 @@
 	}
 
 	const valueFromUrl = $page.url.searchParams.get(param.name);
-	let fieldValue = valueFromUrl ? Number(valueFromUrl) : undefined || param.default;
+	let fieldValue = valueFromUrl ? Number(valueFromUrl) : param.default;
 
 	$: fieldValue, setValue();
 

--- a/console/src/lib/tasks/TaskItemCard.svelte
+++ b/console/src/lib/tasks/TaskItemCard.svelte
@@ -8,7 +8,7 @@
 	<div
 		class="px-6 py-8 bg-grey bg-opacity-5 rounded-xl dark:bg-white dark:bg-opacity-10 border border-white dark:border-black hover:border dark:hover:border hover:border-purple dark:hover:border-purple"
 	>
-		<h3 class="text-4xl mb-4">{command.emoji}</h3>
+		<h3 class="text-4xl mb-4">{command.emoji || '▶️'}</h3>
 		<p class="text-black font-medium dark:text-white">{command.display_name}</p>
 	</div>
 </a>

--- a/console/src/lib/tasks/Textarea.svelte
+++ b/console/src/lib/tasks/Textarea.svelte
@@ -2,6 +2,7 @@
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
 	import { onMount } from 'svelte';
+	import { page } from '$app/stores';
 	import type { TextParam } from './api';
 
 	export let param: TextParam;
@@ -26,12 +27,7 @@
 	}
 
 	onMount(() => {
-		const urlParams = new URLSearchParams(window.location.search);
-		for (const [key, value] of urlParams) {
-			if (key === param.name) {
-				fieldValue = value;
-			}
-		}
+		fieldValue = $page.url.searchParams.get(param.name) || '';
 	});
 
 	let fieldValue = param.default;

--- a/console/src/lib/tasks/Textarea.svelte
+++ b/console/src/lib/tasks/Textarea.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
-
+	import { onMount } from 'svelte';
 	import type { TextParam } from './api';
 
 	export let param: TextParam;
@@ -24,6 +24,15 @@
 	if (param.required) {
 		fieldValidators.push(required);
 	}
+
+	onMount(() => {
+		const urlParams = new URLSearchParams(window.location.search);
+		for (const [key, value] of urlParams) {
+			if (key === param.name) {
+				fieldValue = value;
+			}
+		}
+	});
 
 	let fieldValue = param.default;
 	$: fieldValue, setValue();

--- a/console/src/lib/tasks/Textarea.svelte
+++ b/console/src/lib/tasks/Textarea.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { Writable } from 'svelte/store';
 	import { validators, required, type Validator, Hint } from 'svelte-use-form';
-	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
 	import type { TextParam } from './api';
 
@@ -26,11 +25,7 @@
 		fieldValidators.push(required);
 	}
 
-	onMount(() => {
-		fieldValue = $page.url.searchParams.get(param.name) || '';
-	});
-
-	let fieldValue = param.default;
+	let fieldValue = $page.url.searchParams.get(param.name) || param.default;
 	$: fieldValue, setValue();
 
 	const setValue = () => {


### PR DESCRIPTION
If a parameter key in the URL matches a param name, the relevant field will be populated with the key's value.

Works for:

**String & textarea**
e.g greeting = hello world

**Checkbox**
e.g check=true

**Number**
e.g cost = 200
