### PR TITLE
Added support for pipeline `done`

### DIFF
--- a/dsl/done.go
+++ b/dsl/done.go
@@ -1,0 +1,68 @@
+package dsl
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/manterfield/fast-ctyjson/ctyjson"
+	"github.com/rs/zerolog"
+)
+
+func DecodeDoneBlock(ctx context.Context, hop *HopAST, on *OnAST, block *hcl.Block, evalctx *hcl.EvalContext, logger zerolog.Logger) (*DoneAST, error) {
+	done := &DoneAST{}
+
+	bc, d := block.Body.Content(doneSchema)
+	if d.HasErrors() {
+		return done, errors.New(d.Error())
+	}
+
+	errorVal, err := decodeDoneAttr(bc.Attributes[ErrorAttr], evalctx, true, logger)
+	if err != nil {
+		return nil, err
+	}
+	if errorVal != nil {
+		done.Errored = true
+	}
+
+	resultVal, err := decodeDoneAttr(bc.Attributes[ResultAttr], evalctx, false, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	if resultVal != nil && errorVal == nil {
+		done.Completed = true
+	}
+
+	if resultVal != nil || errorVal != nil {
+		return done, nil
+	}
+
+	return nil, err
+}
+
+func decodeDoneAttr(attr *hcl.Attribute, evalctx *hcl.EvalContext, falseAsNull bool, logger zerolog.Logger) ([]byte, error) {
+	if attr == nil {
+		return nil, nil
+	}
+
+	val, d := attr.Expr.Value(evalctx)
+	if d.HasErrors() {
+		logger.Debug().Msgf("Evaluation skipped on 'done' block '%s', defaulting to null: %s", attr.Name, d.Error())
+		return nil, nil
+	}
+
+	// As a syntax convenience, we interpret false values as null in done.error
+	if falseAsNull && val.False() {
+		return nil, nil
+	}
+
+	jsonVal := ctyjson.SimpleJSONValue{Value: val}
+	valBytes, err := jsonVal.MarshalJSON()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return valBytes, err
+}

--- a/dsl/parse_test.go
+++ b/dsl/parse_test.go
@@ -103,7 +103,7 @@ func TestValidParseResponseStep(t *testing.T) {
 	// Ensure the slugs align with what we want
 	assert.Equal(t, hop.Ons[0].Calls[0].Slug, "a_sensor-first_task")
 
-	// Ensure the done block is generated and check the values
+	// Ensure the done block is empty
 	assert.Nil(t, hop.Ons[0].Done)
 }
 
@@ -143,8 +143,8 @@ func TestValidParseDone(t *testing.T) {
 	require.NotNil(t, hop.Ons[0].Done)
 
 	done := hop.Ons[0].Done
-	assert.True(t, done.Completed)
-	assert.False(t, done.Errored)
+	assert.NotNil(t, done.Result)
+	assert.NoError(t, done.Error)
 }
 
 func TestInvalidParse(t *testing.T) {

--- a/dsl/parse_test.go
+++ b/dsl/parse_test.go
@@ -99,6 +99,15 @@ func TestValidParseResponseStep(t *testing.T) {
 
 	// Ensure the slugs align with what we want
 	assert.Equal(t, hop.Ons[0].Calls[0].Slug, "a_sensor-first_task")
+
+	// Ensure the result is generated
+	// and finally check the result block
+	require.Len(t, hop.Ons[0].Results, 1)
+
+	result := hop.Ons[0].Results[0]
+	assert.True(t, result.Completed)
+	assert.False(t, result.Errored)
+	assert.True(t, result.Done)
 }
 
 func TestInvalidParse(t *testing.T) {
@@ -134,4 +143,8 @@ func TestSlugify(t *testing.T) {
 
 	result = slugify("change_opened", "hello_world")
 	assert.Equal(t, "change_opened-hello_world", result)
+}
+
+func TestResults(t *testing.T) {
+	t.Skip("Not implemented: Test result blocks have expected values")
 }

--- a/dsl/schema.go
+++ b/dsl/schema.go
@@ -7,11 +7,10 @@ import (
 )
 
 var (
-	CompletedAttr = "completed"
-	ErroredAttr   = "errored"
-	OutputsAttr   = "outputs"
-	IfAttr        = "if"
-	NameAttr      = "name"
+	ErrorAttr  = "error"
+	ResultAttr = "result"
+	IfAttr     = "if"
+	NameAttr   = "name"
 
 	HopSchema = &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{},
@@ -35,7 +34,7 @@ var (
 				LabelNames: []string{"taskType"},
 			},
 			{
-				Type: ResultID,
+				Type: DoneID,
 			},
 		},
 		Attributes: []hcl.AttributeSchema{
@@ -54,13 +53,12 @@ var (
 		},
 	}
 
-	ResultID     = "result"
-	resultSchema = &hcl.BodySchema{
+	DoneID     = "done"
+	doneSchema = &hcl.BodySchema{
 		Blocks: []hcl.BlockHeaderSchema{},
 		Attributes: []hcl.AttributeSchema{
-			{Name: CompletedAttr, Required: false},
-			{Name: ErroredAttr, Required: false},
-			{Name: OutputsAttr, Required: false},
+			{Name: ErrorAttr, Required: false},
+			{Name: ResultAttr, Required: false},
 		},
 	}
 
@@ -109,7 +107,7 @@ type OnAST struct {
 	EventType string
 	Name      string
 	Calls     []CallAST
-	Results   []ResultAST
+	Done      *DoneAST
 	ConditionalAST
 }
 
@@ -121,11 +119,11 @@ type CallAST struct {
 	ConditionalAST
 }
 
-type ResultAST struct {
+type DoneAST struct {
 	Completed bool
 	Errored   bool
-	Done      bool
-	Outputs   []byte
+	Error     []byte
+	Result    []byte
 }
 
 type ConditionalAST struct {

--- a/dsl/schema.go
+++ b/dsl/schema.go
@@ -2,6 +2,7 @@ package dsl
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/hcl/v2"
 )
@@ -85,6 +86,7 @@ type HopAST struct {
 	Ons          []OnAST
 	Tasks        []TaskAST
 	SlugRegister map[string]bool
+	StartedAt    time.Time
 }
 
 func (h *HopAST) ListTasks() []TaskAST {
@@ -120,10 +122,8 @@ type CallAST struct {
 }
 
 type DoneAST struct {
-	Completed bool
-	Errored   bool
-	Error     []byte
-	Result    []byte
+	Error  error
+	Result []byte
 }
 
 type ConditionalAST struct {

--- a/dsl/schema.go
+++ b/dsl/schema.go
@@ -7,8 +7,11 @@ import (
 )
 
 var (
-	IfAttr   = "if"
-	NameAttr = "name"
+	CompletedAttr = "completed"
+	ErroredAttr   = "errored"
+	OutputsAttr   = "outputs"
+	IfAttr        = "if"
+	NameAttr      = "name"
 
 	HopSchema = &hcl.BodySchema{
 		Attributes: []hcl.AttributeSchema{},
@@ -31,6 +34,9 @@ var (
 				Type:       CallID,
 				LabelNames: []string{"taskType"},
 			},
+			{
+				Type: ResultID,
+			},
 		},
 		Attributes: []hcl.AttributeSchema{
 			{Name: "name", Required: false},
@@ -45,6 +51,16 @@ var (
 			{Name: "name", Required: false},
 			{Name: IfAttr, Required: false},
 			{Name: "inputs", Required: false},
+		},
+	}
+
+	ResultID     = "result"
+	resultSchema = &hcl.BodySchema{
+		Blocks: []hcl.BlockHeaderSchema{},
+		Attributes: []hcl.AttributeSchema{
+			{Name: CompletedAttr, Required: false},
+			{Name: ErroredAttr, Required: false},
+			{Name: OutputsAttr, Required: false},
 		},
 	}
 
@@ -64,20 +80,7 @@ var (
 		},
 	}
 
-	ParamID = "param"
-	// TODO: Check if this schema is actually used still.
-	// We might only be using the tags in the ParamAST
-	paramSchema = &hcl.BodySchema{
-		Attributes: []hcl.AttributeSchema{
-			{Name: "flag", Required: false},
-			{Name: "display_name", Required: false},
-			{Name: "type", Required: false},
-			{Name: "default", Required: false},
-			{Name: "help", Required: false},
-			{Name: "shortflag", Required: false},
-			{Name: "required", Required: false},
-		},
-	}
+	ParamID = "param" // Schema defined via tags on the struct
 )
 
 type HopAST struct {
@@ -106,6 +109,7 @@ type OnAST struct {
 	EventType string
 	Name      string
 	Calls     []CallAST
+	Results   []ResultAST
 	ConditionalAST
 }
 
@@ -115,6 +119,13 @@ type CallAST struct {
 	Name     string
 	Inputs   []byte
 	ConditionalAST
+}
+
+type ResultAST struct {
+	Completed bool
+	Errored   bool
+	Done      bool
+	Outputs   []byte
 }
 
 type ConditionalAST struct {

--- a/dsl/testdata/valid.hops
+++ b/dsl/testdata/valid.hops
@@ -22,6 +22,9 @@ on change_merged {
     }
   }
 
+  // This done block should never match, since the call is never made
+  done {error = second_task.errored}
+
   call index_id_call {}
 
   call depends_call {
@@ -29,13 +32,9 @@ on change_merged {
     if = first_task.done
   }
 
-  result {
-    completed = first_task.completed
-    errored = first_task.errored
-
-    outputs = {
-      foo = "bar"
-    }
+  done {
+    error = depends.errored
+    result = depends.completed
   }
 }
 

--- a/dsl/testdata/valid.hops
+++ b/dsl/testdata/valid.hops
@@ -28,6 +28,15 @@ on change_merged {
     name = "depends"
     if = first_task.done
   }
+
+  result {
+    completed = first_task.completed
+    errored = first_task.errored
+
+    outputs = {
+      foo = "bar"
+    }
+  }
 }
 
 on change {

--- a/nats/client.go
+++ b/nats/client.go
@@ -130,11 +130,23 @@ func (c *Client) ConsumeSequences(ctx context.Context, handler SequenceHandler) 
 		}
 
 		if hopsMsg.MessageId == HopsMessageId {
-			c.logger.Debugf("Skipping hops assignment message")
+			c.logger.Debugf("Skipping 'hops assignment' message")
 
 			err := DoubleAck(ctx, msg)
 			if err != nil {
-				c.logger.Errf(err, "Unable to ack hops assignment message")
+				c.logger.Errf(err, "Unable to ack 'hops assignment' message")
+			}
+
+			return
+		}
+
+		if hopsMsg.Done {
+			// TODO: Actually finalise the pipeline here
+			c.logger.Debugf("Skipping 'pipeline done' message")
+
+			err := DoubleAck(ctx, msg)
+			if err != nil {
+				c.logger.Errf(err, "Unable to ack 'pipeline done' message")
 			}
 
 			return
@@ -167,7 +179,6 @@ func (c *Client) FetchMessageBundle(ctx context.Context, newMsg *MsgMeta) (Messa
 	filter := newMsg.SequenceFilter()
 
 	// TODO: Create a deadline for the context
-
 	consumerConf := jetstream.OrderedConsumerConfig{
 		FilterSubjects: []string{filter},
 		DeliverPolicy:  jetstream.DeliverAllPolicy,

--- a/nats/msgschema.go
+++ b/nats/msgschema.go
@@ -9,6 +9,7 @@ import (
 )
 
 const HopsMessageId = "hops"
+const DoneMessageId = "done"
 
 type (
 	// HopsResultMeta is metadata included in the top level of a result message
@@ -23,6 +24,7 @@ type (
 		AppName          string
 		Channel          string
 		ConsumerSequence uint64
+		Done             bool
 		HandlerName      string
 		MessageId        string
 		SequenceId       string
@@ -108,6 +110,10 @@ func (m *MsgMeta) initTokens() error {
 	m.Channel = subjectTokens[1]
 	m.SequenceId = subjectTokens[2]
 	m.MessageId = subjectTokens[3]
+
+	if len(subjectTokens) == 5 {
+		m.Done = subjectTokens[4] == DoneMessageId
+	}
 
 	if m.Channel == ChannelNotify {
 		return nil


### PR DESCRIPTION
This adds support for the pipeline `done` block in addition to adding default behaviour for marking a pipeline as `done`

Primarily this feature is foundational work enabling additional features in our roadmap, such as:
- Pipeline visualisations with state
- Garbage collection of completed pipelines
- Calling pipelines from other pipelines and getting results
- Returning configurable results back to tasks