### PR TITLE
Updated nats to use a single client with multiple consumers

### DIFF
--- a/cmd/replay.go
+++ b/cmd/replay.go
@@ -62,7 +62,8 @@ func replayCmd(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("Failed to read hops file: %w", err)
 			}
 
-			natsClient, err := nats.NewClient(keyFile.NatsUrl(), keyFile.AccountId, &zlog, nats.ReplayClient(viper.GetString("event")))
+			fromConsumer := "replay"
+			natsClient, err := nats.NewClient(keyFile.NatsUrl(), keyFile.AccountId, &zlog, nats.ReplayClient(fromConsumer, viper.GetString("event")))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to start NATS client")
 				return err
@@ -75,6 +76,7 @@ func replayCmd(ctx context.Context) *cobra.Command {
 				ctx,
 				hops,
 				natsClient,
+				fromConsumer,
 				logger,
 			); err != nil {
 				logger.Error().Err(err).Msg("Replay failed")

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,6 +69,7 @@ func serverCmd(ctx context.Context) *cobra.Command {
 				ctx,
 				hops,
 				natsClient,
+				nats.DefaultConsumerName,
 				logger,
 			); err != nil {
 				logger.Error().Err(err).Msg("Server start failed")
@@ -82,8 +83,7 @@ func serverCmd(ctx context.Context) *cobra.Command {
 	return serverCmd
 }
 
-// TODO: Add context cancellation with cleanup on SIGINT/SIGTERM https://medium.com/@matryer/make-ctrl-c-cancel-the-context-context-bd006a8ad6ff
-func server(ctx context.Context, hops *dsl.HopsFiles, natsClient *nats.Client, logger zerolog.Logger) error {
+func server(ctx context.Context, hops *dsl.HopsFiles, natsClient *nats.Client, fromConsumer string, logger zerolog.Logger) error {
 	logger.Info().Msg("Listening for events")
 
 	runner, err := runner.NewRunner(natsClient, hops, logger)
@@ -91,5 +91,5 @@ func server(ctx context.Context, hops *dsl.HopsFiles, natsClient *nats.Client, l
 		return err
 	}
 
-	return runner.Run(ctx)
+	return runner.Run(ctx, fromConsumer)
 }

--- a/internal/k8sapp/k8s.go
+++ b/internal/k8sapp/k8s.go
@@ -98,6 +98,10 @@ func NewK8sHandler(
 	return k, nil
 }
 
+func (k *K8sHandler) AppName() string {
+	return "k8s"
+}
+
 func (k *K8sHandler) Handlers() map[string]worker.Handler {
 	handlers := map[string]worker.Handler{}
 	handlers["run"] = k.RunPod

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -23,7 +23,7 @@ import (
 
 type (
 	NatsClient interface {
-		ConsumeSequences(context.Context, nats.SequenceHandler) error
+		ConsumeSequences(context.Context, string, nats.SequenceHandler) error
 		GetMsg(ctx context.Context, subjTokens ...string) (*jetstream.RawStreamMsg, error)
 		GetSysObject(key string) ([]byte, error)
 		Publish(context.Context, []byte, ...string) (*jetstream.PubAck, bool, error)
@@ -64,7 +64,7 @@ func NewRunner(natsClient NatsClient, hops *dsl.HopsFiles, logger zerolog.Logger
 	return runner, nil
 }
 
-func (r *Runner) Run(ctx context.Context) error {
+func (r *Runner) Run(ctx context.Context, fromConsumer string) error {
 	c := cron.New()
 	defer c.Stop()
 
@@ -73,7 +73,7 @@ func (r *Runner) Run(ctx context.Context) error {
 	}
 	c.Start()
 
-	return r.natsClient.ConsumeSequences(ctx, r)
+	return r.natsClient.ConsumeSequences(ctx, fromConsumer, r)
 }
 
 func (r *Runner) SequenceCallback(

--- a/nats/client_test.go
+++ b/nats/client_test.go
@@ -24,7 +24,7 @@ func TestNewClient(t *testing.T) {
 	}
 
 	assert.NotNil(t, hopsNats.JetStream, "HopsNats should initialise JetStream")
-	assert.NotNil(t, hopsNats.Consumer, "HopsNats should initialise the Consumer")
+	assert.NotNil(t, hopsNats.Consumers[DefaultConsumerName], "HopsNats should initialise the Consumer")
 }
 
 func TestClientConsume(t *testing.T) {
@@ -43,7 +43,7 @@ func TestClientConsume(t *testing.T) {
 	receivedChan := make(chan testMsg)
 
 	go func() {
-		hopsNats.Consume(ctx, func(m jetstream.Msg) {
+		hopsNats.Consume(ctx, DefaultConsumerName, func(m jetstream.Msg) {
 			m.DoubleAck(ctx) // Ack before logging to avoid race condition in tests
 			receivedChan <- testMsg{
 				subject: m.Subject(),
@@ -94,7 +94,7 @@ func TestClientConsumeSequences(t *testing.T) {
 	sqncHandler := &testSequenceHandler{receivedChan: receivedChan}
 
 	go func() {
-		hopsNats.ConsumeSequences(ctx, sqncHandler)
+		hopsNats.ConsumeSequences(ctx, DefaultConsumerName, sqncHandler)
 	}()
 
 	_, _, err := hopsNats.Publish(ctx, []byte("One"), ChannelNotify, "SEQ_ID", "event")


### PR DESCRIPTION
Updated nats to use a single client with multiple consumers ahead of adding more local workers.

This is more efficient, and also makes it easier to add multiple workers in a single instance of hops. Multiple workers are required for several pending items on the roadmap.