### PR TITLE
Fix addkey function breaks if dir not there

### DIFF
--- a/cmd/addkey.go
+++ b/cmd/addkey.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/hiphops-io/hops/logs"
 	"github.com/urfave/cli/v2"
@@ -68,17 +69,24 @@ func initAddKeyCommand(commonFlags []cli.Flag) *cli.Command {
 	}
 }
 
-func overwriteFile(filepath string, content []byte) error {
-	writeFile, err := os.OpenFile(filepath, os.O_RDWR|os.O_CREATE, 0666)
+func overwriteFile(fileNamePath string, content []byte) error {
+	// Create all directories in the path if they do not exist
+	dirPath := filepath.Dir(fileNamePath)
+	if err := os.MkdirAll(dirPath, 0755); err != nil {
+		return err
+	}
+
+	// Open the file with flags to create it if it doesn't exist, and for read-write
+	writeFile, err := os.OpenFile(fileNamePath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
 	if err != nil {
 		return err
 	}
 	defer writeFile.Close()
 
-	writeFile.Truncate(0)
-	writeFile.Seek(0, 0)
-	writeFile.Write(content)
-	writeFile.Sync()
+	// Write the content to the file
+	if _, err := writeFile.Write(content); err != nil {
+		return err
+	}
 
-	return nil
+	return writeFile.Sync()
 }

--- a/cmd/addkey_test.go
+++ b/cmd/addkey_test.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOverwriteFile(t *testing.T) {
+	// Get the current umask
+	originalUmask := syscall.Umask(0)
+	syscall.Umask(originalUmask)
+
+	// Define the expected permissions, accounting for the umask
+	expectedPerms := os.FileMode(0666) &^ os.FileMode(originalUmask)
+
+	// Test successful overwriting of an existing file
+	t.Run("overwrite existing file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "testfile.txt")
+
+		initialContent := []byte("initial content")
+		err := overwriteFile(filePath, initialContent)
+		if err != nil {
+			t.Fatal("Failed to write file with initial content:", err)
+		}
+
+		newContent := []byte("new content")
+		err = overwriteFile(filePath, newContent)
+		if err != nil {
+			t.Fatal("Failed to overwrite existing file with new content:", err)
+		}
+
+		contents, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatal("Failed to read file contents:", err)
+		}
+		assert.Equal(t, newContent, contents)
+
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			t.Fatal("Failed to get file info:", err)
+		}
+		assert.Equal(t, fileInfo.Mode().Perm(), expectedPerms, "File permissions should be as expected considering umask")
+	})
+
+	// Test creation and writing to a new file if it doesn't exist
+	// Kind of covered in previous test, but good to have a specific test
+	t.Run("create and write new file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		filePath := filepath.Join(tempDir, "newfile.txt")
+
+		content := []byte("new file content")
+		err := overwriteFile(filePath, content)
+		if err != nil {
+			t.Fatal("Failed to write file with new content:", err)
+		}
+
+		contents, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatal("Failed to read file contents:", err)
+		}
+		assert.Equal(t, content, contents)
+
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			t.Fatal("Failed to get file info:", err)
+		}
+		assert.Equal(t, fileInfo.Mode().Perm(), expectedPerms, "File permissions should be 0660")
+	})
+
+	// Test creation of directory and file if they don't exist
+	t.Run("create directory and file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		newDir := filepath.Join(tempDir, "newdir")
+		filePath := filepath.Join(newDir, "newfile.txt")
+
+		content := []byte("content for new file in new directory")
+		err := overwriteFile(filePath, content)
+		if err != nil {
+			t.Fatal("Failed to create directory and file:", err)
+		}
+
+		// Check if directory was created
+		_, err = os.Stat(newDir)
+		if err != nil {
+			t.Fatal("Failed to stat the new directory:", err)
+		}
+
+		// Check if file was created in the new directory
+		contents, err := os.ReadFile(filePath)
+		if err != nil {
+			t.Fatal("Failed to read file contents:", err)
+		}
+		assert.Equal(t, content, contents)
+
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			t.Fatal("Failed to get file info:", err)
+		}
+		assert.Equal(t, fileInfo.Mode().Perm(), expectedPerms, "File permissions should be as expected considering umask")
+	})
+
+	// Test invalid input (e.g., directory path)
+	t.Run("invalid input - directory path", func(t *testing.T) {
+		tempDir := t.TempDir()
+		err := overwriteFile(tempDir, []byte("content"))
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
`addkey` command fails if directory not present. This includes the default `~/.hops` directory.