### PR TITLE
Change function name to addOrUpdateKeyfile

### DIFF
--- a/cmd/addkey.go
+++ b/cmd/addkey.go
@@ -58,7 +58,7 @@ func initAddKeyCommand(commonFlags []cli.Flag) *cli.Command {
 		Action: func(c *cli.Context) error {
 			logger := logs.InitLogger(c.Bool("debug"))
 
-			err := overwriteFile(c.String("keyfile"), []byte(c.String("keydata")))
+			err := addOrUpdateKeyfile(c.String("keyfile"), []byte(c.String("keydata")))
 			if err != nil {
 				logger.Error().Err(err).Msg("Failed to write keyfile")
 				return err
@@ -69,7 +69,9 @@ func initAddKeyCommand(commonFlags []cli.Flag) *cli.Command {
 	}
 }
 
-func overwriteFile(fileNamePath string, content []byte) error {
+// addOrUpdateKeyfile writes the keyfile to the specified path, creating all directories in the path if they do not
+// exist. Overwrites the file if it already exists.
+func addOrUpdateKeyfile(fileNamePath string, content []byte) error {
 	// Create all directories in the path if they do not exist
 	dirPath := filepath.Dir(fileNamePath)
 	if err := os.MkdirAll(dirPath, 0755); err != nil {

--- a/cmd/addkey_test.go
+++ b/cmd/addkey_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestOverwriteFile(t *testing.T) {
+func TestAddKeyfile(t *testing.T) {
 	// Get the current umask
 	originalUmask := syscall.Umask(0)
 	syscall.Umask(originalUmask)
@@ -23,13 +23,13 @@ func TestOverwriteFile(t *testing.T) {
 		filePath := filepath.Join(tempDir, "testfile.txt")
 
 		initialContent := []byte("initial content")
-		err := overwriteFile(filePath, initialContent)
+		err := addOrUpdateKeyfile(filePath, initialContent)
 		if err != nil {
 			t.Fatal("Failed to write file with initial content:", err)
 		}
 
 		newContent := []byte("new content")
-		err = overwriteFile(filePath, newContent)
+		err = addOrUpdateKeyfile(filePath, newContent)
 		if err != nil {
 			t.Fatal("Failed to overwrite existing file with new content:", err)
 		}
@@ -54,7 +54,7 @@ func TestOverwriteFile(t *testing.T) {
 		filePath := filepath.Join(tempDir, "newfile.txt")
 
 		content := []byte("new file content")
-		err := overwriteFile(filePath, content)
+		err := addOrUpdateKeyfile(filePath, content)
 		if err != nil {
 			t.Fatal("Failed to write file with new content:", err)
 		}
@@ -79,7 +79,7 @@ func TestOverwriteFile(t *testing.T) {
 		filePath := filepath.Join(newDir, "newfile.txt")
 
 		content := []byte("content for new file in new directory")
-		err := overwriteFile(filePath, content)
+		err := addOrUpdateKeyfile(filePath, content)
 		if err != nil {
 			t.Fatal("Failed to create directory and file:", err)
 		}
@@ -107,7 +107,7 @@ func TestOverwriteFile(t *testing.T) {
 	// Test invalid input (e.g., directory path)
 	t.Run("invalid input - directory path", func(t *testing.T) {
 		tempDir := t.TempDir()
-		err := overwriteFile(tempDir, []byte("content"))
+		err := addOrUpdateKeyfile(tempDir, []byte("content"))
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
Makes function name specific to the purpose of the function, and makes it clear this is not a generic function.

Function:

1) Sets permissions
2) Creates directories
3) Creates or updates the key file