### PR TITLE
Ensure reload of schedules once hops file save

### DIFF
--- a/internal/hops/runner.go
+++ b/internal/hops/runner.go
@@ -38,7 +38,6 @@ func NewRunner(natsClient *nats.Client, hopsFileLoader *HopsFileLoader, logger z
 		logger:         logger,
 		natsClient:     natsClient,
 		hopsFileLoader: hopsFileLoader,
-		cron:           cron.New(),
 		cache:          cache.New(5*time.Minute, 10*time.Minute),
 	}
 
@@ -76,9 +75,16 @@ func (r *Runner) Reload(ctx context.Context) error {
 }
 
 func (r *Runner) Run(ctx context.Context, fromConsumer string) error {
-	defer r.cron.Stop()
 
-	return r.natsClient.ConsumeSequences(ctx, fromConsumer, r)
+	err := r.natsClient.ConsumeSequences(ctx, fromConsumer, r)
+
+	if err != nil {
+		return err
+	}
+
+	r.cron.Stop()
+
+	return nil
 }
 
 func (r *Runner) SequenceCallback(

--- a/internal/hops/runner.go
+++ b/internal/hops/runner.go
@@ -70,7 +70,7 @@ func (r *Runner) Reload(ctx context.Context) error {
 		return fmt.Errorf("Unable to create schedules %w", err)
 	}
 
-	r.resetCron()
+	r.setCron()
 
 	return nil
 }
@@ -248,8 +248,11 @@ func (r *Runner) prepareHopsSchedules() error {
 	return nil
 }
 
-func (r *Runner) resetCron() {
-	r.cron.Stop()
+func (r *Runner) setCron() {
+
+	if r.cron != nil {
+		r.cron.Stop()
+	}
 
 	r.cron = cron.New()
 

--- a/internal/hops/runner.go
+++ b/internal/hops/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"sync"
 	"time"
@@ -72,8 +71,6 @@ func (r *Runner) Reload(ctx context.Context) error {
 	}
 
 	r.resetCron()
-
-	log.Println(r.cron.Entries())
 
 	return nil
 }

--- a/internal/hops/runner.go
+++ b/internal/hops/runner.go
@@ -76,15 +76,13 @@ func (r *Runner) Reload(ctx context.Context) error {
 
 func (r *Runner) Run(ctx context.Context, fromConsumer string) error {
 
-	err := r.natsClient.ConsumeSequences(ctx, fromConsumer, r)
+	defer func() {
+		if r.cron != nil {
+			r.cron.Stop()
+		}
+	}()
 
-	if err != nil {
-		return err
-	}
-
-	r.cron.Stop()
-
-	return nil
+	return r.natsClient.ConsumeSequences(ctx, fromConsumer, r)
 }
 
 func (r *Runner) SequenceCallback(


### PR DESCRIPTION
This update incorporates management of cron jobs into the `Runner` struct, allowing it to handle scheduling tasks within the application. Now, 'Reload' will also stop any existing cron jobs before starting new ones. Furthermore, a cron field was introduced in Runner struct. Log entries are temporarily put in place to monitor and validate these changes.