### PR TITLE
Improve error message when hops files cannot be read

### DIFF
--- a/dsl/read.go
+++ b/dsl/read.go
@@ -103,7 +103,7 @@ func ReadHopsFileContents(hopsFileContent []FileContent) (*hcl.BodyContent, stri
 	}
 
 	if len(content.Blocks) == 0 {
-		return nil, "", errors.New("Could not read hops files. Ensure the hops folder path is correctly defined. The hops folder should contain at least one resource")
+		return nil, "", errors.New("Ensure the hops folder path is correctly defined. The hops folder should contain at least one resource")
 	}
 
 	filesSha := sha256Hash.Sum(nil)

--- a/dsl/read.go
+++ b/dsl/read.go
@@ -103,7 +103,7 @@ func ReadHopsFileContents(hopsFileContent []FileContent) (*hcl.BodyContent, stri
 	}
 
 	if len(content.Blocks) == 0 {
-		return nil, "", errors.New("Ensure the hops folder path is correctly defined. The hops folder should contain at least one resource")
+		return nil, "", errors.New("Ensure --hops is set to a valid dir containing automations. A valid automation must include at least one non-empty *.hops file")
 	}
 
 	filesSha := sha256Hash.Sum(nil)

--- a/dsl/read.go
+++ b/dsl/read.go
@@ -103,7 +103,7 @@ func ReadHopsFileContents(hopsFileContent []FileContent) (*hcl.BodyContent, stri
 	}
 
 	if len(content.Blocks) == 0 {
-		return nil, "", errors.New("At least one resource must be defined in your hops config(s)")
+		return nil, "", errors.New("Could not read hops files. Ensure the hops folder path is correctly defined. The hops folder should contain at least one resource")
 	}
 
 	filesSha := sha256Hash.Sum(nil)

--- a/internal/hops/start.go
+++ b/internal/hops/start.go
@@ -3,7 +3,6 @@ package hops
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"github.com/oklog/run"
@@ -76,7 +75,6 @@ func (h *HopsServer) Start(ctx context.Context) error {
 
 	hopsLoader, err := NewHopsFileLoader(h.HopsPath)
 	if err != nil {
-		err := fmt.Errorf("Failed to read hops files: %w", err)
 		h.Logger.Error().Err(err).Msg("Start failed")
 		return err
 	}


### PR DESCRIPTION
The error message for the case where the hops files are empty or not correctly defined has been enhanced. The update provides more detailed information, instructing the user to check the hops folder path and ensure that it contains at least one resource.