### PR TITLE
Make hops tolerant of failed config parsing when in --watch mode

### DIFF
--- a/console/src/routes/+page.ts
+++ b/console/src/routes/+page.ts
@@ -7,6 +7,7 @@ export const load: PageLoad = async () => {
 
 	try {
 		tasks = await ky.get(`${PUBLIC_BACKEND_URL}/tasks`).json();
+		tasks ??= [];
 	} catch (error) {
 		// TODO: Would be better to let users know something went wrong,
 		//       rather than just show empty

--- a/internal/hops/errors.go
+++ b/internal/hops/errors.go
@@ -1,0 +1,11 @@
+package hops
+
+import "fmt"
+
+type ErrFailedHopsParse struct {
+	message string
+}
+
+func (e ErrFailedHopsParse) Error() string {
+	return fmt.Sprintf("Unable to parse hops: %s", e.message)
+}

--- a/internal/hops/httpserver.go
+++ b/internal/hops/httpserver.go
@@ -50,7 +50,7 @@ func NewHTTPServer(addr string, hopsFileLoader *HopsFileLoader, natsClient *nats
 	r := chi.NewRouter()
 	r.Use(middleware.Recoverer)
 	r.Use(middleware.RedirectSlashes)
-	r.Use(logs.AccessLogMiddleware(logger)) // TODO: Make logging less verbose for static/frontend requests
+	r.Use(logs.AccessLogMiddleware(logger))
 	r.Use(Healthcheck(natsClient, "/health"))
 	// TODO: Make CORS configurable and lock down by default. As-is it could be
 	// insecure for production/deployed use.
@@ -94,7 +94,7 @@ func (h *HTTPServer) Reload(ctx context.Context) error {
 	// Serve the tasks API
 	taskHops, err := dsl.ParseHopsTasks(ctx, hopsFiles)
 	if err != nil {
-		return err
+		return ErrFailedHopsParse{err.Error()}
 	}
 
 	h.mu.Lock()

--- a/internal/hops/httpserver.go
+++ b/internal/hops/httpserver.go
@@ -28,6 +28,7 @@ type (
 		natsClient     *nats.Client
 		server         *http.Server
 		taskHops       *dsl.HopAST
+		tolerantParse  bool // tolerantParse makes failed hops parsing non-fatal (useful in --watch mode)
 		updatedAt      int64
 	}
 
@@ -39,8 +40,14 @@ type (
 	}
 )
 
-func NewHTTPServer(addr string, hopsFileLoader *HopsFileLoader, natsClient *nats.Client, logger zerolog.Logger) (*HTTPServer, error) {
-	h := &HTTPServer{hopsFileLoader: hopsFileLoader, logger: logger, natsClient: natsClient}
+func NewHTTPServer(addr string, hopsFileLoader *HopsFileLoader, tolerantParse bool, natsClient *nats.Client, logger zerolog.Logger) (*HTTPServer, error) {
+	h := &HTTPServer{
+		hopsFileLoader: hopsFileLoader,
+		logger:         logger,
+		natsClient:     natsClient,
+		tolerantParse:  tolerantParse,
+		taskHops:       &dsl.HopAST{},
+	}
 
 	err := h.Reload(context.Background())
 	if err != nil {
@@ -93,7 +100,9 @@ func (h *HTTPServer) Reload(ctx context.Context) error {
 	}
 	// Serve the tasks API
 	taskHops, err := dsl.ParseHopsTasks(ctx, hopsFiles)
-	if err != nil {
+	if err != nil && h.tolerantParse {
+		return nil
+	} else if err != nil {
 		return ErrFailedHopsParse{err.Error()}
 	}
 

--- a/internal/hops/start.go
+++ b/internal/hops/start.go
@@ -145,7 +145,7 @@ func (h *HopsServer) startHTTPServer(hopsLoader *HopsFileLoader, natsClient *nat
 		return nil
 	}
 
-	httpServer, err := NewHTTPServer(h.Address, hopsLoader, natsClient, h.Logger)
+	httpServer, err := NewHTTPServer(h.Address, hopsLoader, h.Watch, natsClient, h.Logger)
 	if err != nil {
 		return err
 	}

--- a/internal/hops/start.go
+++ b/internal/hops/start.go
@@ -152,7 +152,14 @@ func (h *HopsServer) startHTTPServer(hopsLoader *HopsFileLoader, natsClient *nat
 
 	if h.Watch {
 		h.reloadManager.Add(10, reload.ReloaderFunc(func(ctx context.Context, id string) error {
-			return httpServer.Reload(ctx)
+			err := httpServer.Reload(ctx)
+			if errors.As(err, &ErrFailedHopsParse{}) {
+				h.Logger.Debug().Msgf("(Ignored in watch mode) %s", err.Error())
+			} else if err != nil {
+				return err
+			}
+
+			return nil
 		}))
 	}
 

--- a/logs/middleware.go
+++ b/logs/middleware.go
@@ -2,6 +2,7 @@ package logs
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/justinas/alice"
@@ -13,6 +14,10 @@ func AccessLogMiddleware(logger zerolog.Logger) func(http.Handler) http.Handler 
 	chain := alice.New()
 	chain = chain.Append(hlog.NewHandler(logger))
 	chain = chain.Append(hlog.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {
+		if strings.HasPrefix(r.URL.Path, "/console") {
+			return
+		}
+
 		hlog.FromRequest(r).Info().
 			Int("status", status).
 			Str("method", r.Method).


### PR DESCRIPTION
- Made watch mode hops tolerant of failed parses (will not cause process to exit)
- Also silenced access logging for console frontend assets, as it was _very_ chatty