### PR TITLE
Fix segfault on os.Stat error

### DIFF
--- a/internal/hops/loadhops.go
+++ b/internal/hops/loadhops.go
@@ -48,12 +48,10 @@ func (d *DirNotifier) Notifier() reload.Notifier {
 		case event := <-d.watcher.Events:
 			if event.Op&fsnotify.Create == fsnotify.Create {
 				// File created, is it a dir?
-				fileInfo, _ := os.Stat(event.Name)
-				// We ignore the error from above as normal use would cause this to
-				// return an error (e.g. when saving files via vim)
-
-				if fileInfo.IsDir() {
-					d.watcher.Add(event.Name)
+				// We ignore the error from os.Stat as normal use would cause this to
+				// return an error (e.g., when saving files via vim).
+				if fileInfo, err := os.Stat(event.Name); err == nil && fileInfo.IsDir() {
+					_ = d.watcher.Add(event.Name)
 				}
 			}
 


### PR DESCRIPTION
Should fix this panic. It only happens occasionally so hard to be certain it's gone. However, there is only one possible cause.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x18 pc=0x101d2acbc]

goroutine 57 [running]:
github.com/hiphops-io/hops/internal/hops.(*DirNotifier).Notifier.func1({0x2?, 0x2?})
	/Users/runner/work/hops/hops/internal/hops/loadhops.go:55 +0x9c
github.com/slok/reload.NotifierFunc.Notify(0x14000121f68?, {0x1027b5158?, 0x1400013e280?})
	/Users/runner/go/pkg/mod/github.com/slok/reload@v0.1.0/reload.go:29 +0x34
github.com/slok/reload.(*Manager).Run.func1.1(...)
	/Users/runner/go/pkg/mod/github.com/slok/reload@v0.1.0/manager.go:95
github.com/slok/reload.(*Manager).Run.func1({0x10279f8a0, 0x1400013a450})
	/Users/runner/go/pkg/mod/github.com/slok/reload@v0.1.0/manager.go:103 +0x5c
created by github.com/slok/reload.(*Manager).Run
	/Users/runner/go/pkg/mod/github.com/slok/reload@v0.1.0/manager.go:91 +0x10c
```