### PR TITLE
Make dockerfile run as non root user

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 **/.svelte-kit
 docker
 assets/console/**/*
+.github/
+deploy/

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Build stage
 FROM golang:alpine as builder
 

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -21,12 +21,17 @@ RUN CGO_ENABLED=0 go build -o /go/bin/app -v main.go
 
 # Final stage
 FROM alpine:3.18
+
 RUN apk --no-cache add ca-certificates
-COPY --from=builder /go/bin/app /hops
+
+# Creates a new user with uid 1000 and a home directory
+RUN adduser -D -u 1000 hops
+USER hops
+WORKDIR /home/hops
+
+COPY --chown=hops:hops --from=builder /go/bin/app ./hops
 
 EXPOSE 8916
 
-ENTRYPOINT [ "/hops" ]
-
+ENTRYPOINT [ "./hops" ]
 CMD ["start"]
-# TODO: Run as non-root?

--- a/deploy/kustomize/deployment.yaml
+++ b/deploy/kustomize/deployment.yaml
@@ -19,6 +19,11 @@ spec:
         command: ["./hops"]
         args: ["start", "--address=0.0.0.0:8916", "--keyfile=./hiphops-key/hiphops.key", "--hops=./hops-conf/", "--serve-k8sapp"]
         imagePullPolicy: Always
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 1000
         ports:
         - containerPort: 8916
 

--- a/deploy/kustomize/deployment.yaml
+++ b/deploy/kustomize/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hiphops
+  name: hops
 spec:
   selector:
     matchLabels:
@@ -12,12 +12,12 @@ spec:
       labels:
         app: hiphops
     spec:
-      serviceAccountName: hiphops-worker
+      serviceAccountName: hops-worker
       containers:
-      - name: hiphops
-        image: hiphops/hiphops:v0.6.1
-        command: ["/hops"]
-        args: ["start", "--address=0.0.0.0:8916", "--keyfile=/root/hiphops-key/hiphops.key", "--hops=/root/hops/"]
+      - name: hops
+        image: hiphops/hiphops:v0.15.3
+        command: ["./hops"]
+        args: ["start", "--address=0.0.0.0:8916", "--keyfile=./hiphops-key/hiphops.key", "--hops=./hops-conf/", "--serve-k8sapp"]
         imagePullPolicy: Always
         ports:
         - containerPort: 8916
@@ -53,18 +53,15 @@ spec:
           timeoutSeconds: 1
 
         volumeMounts:
-        - name: hiphops-conf
-          mountPath: /root/hops
+        - name: hops-conf
+          mountPath: /home/hops/hops-conf/automations/
         - name: hiphops-key
-          mountPath: /root/hiphops-key
+          mountPath: /home/hops/hiphops-key
 
       volumes:
-      - name: hiphops-conf
+      - name: hops-conf
         configMap:
-          name: hiphops-conf
-          items:
-            - key: main.hops
-              path: main/main.hops
+          name: hops-conf
       - name: hiphops-key
         secret:
           secretName: hiphops-key

--- a/deploy/kustomize/rbac.yaml
+++ b/deploy/kustomize/rbac.yaml
@@ -2,13 +2,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: hiphops-worker
+  name: hops-worker
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: hiphops-worker
+  name: hops-worker
 rules:
 - apiGroups: [""]
   resources:
@@ -28,12 +28,12 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: hiphops-worker
+  name: hops-worker
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: hiphops-worker
+  name: hops-worker
 subjects:
 - kind: ServiceAccount
-  name: hiphops-worker
+  name: hops-worker
   namespace: default

--- a/deploy/kustomize/service.yaml
+++ b/deploy/kustomize/service.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: hiphops
+  name: hops
 spec:
   ports:
   - name: http
@@ -10,4 +10,4 @@ spec:
     targetPort: 8916
     protocol: TCP
   selector:
-    app: hiphops
+    app: hops


### PR DESCRIPTION
NB: This will require changing where the volumes are mounted as the new non-root user doesn't have access to `/root`

### k8s
* Update deployments to match the latest example I've seen
* Use new `/home/hops/` directory
* Add securityContext settings
  * allowPrivilegeEscalation: false
  * readOnlyRootFilesystem: true
  * runAsNonRoot: true
  * runAsUser: 1000

### Dockerfile
* Add `.github` and `deploy/` to `.dockerignore`
* Add new `hops` user with uid `1000` and home directory `/home/hops/`
* Use `/home/hops` as the final stage's working directory
* Switch to `hops` user in final stage
* Copy built files with the `--chown` directive to change the owner to the new `hops` user